### PR TITLE
[L2ERC20TokenBridge.sol] Withdrawal functions in L2ERC20TokenBridge contract do not verify if the sender is an EOA 

### DIFF
--- a/contracts/mantle/L2ERC20TokenBridge.sol
+++ b/contracts/mantle/L2ERC20TokenBridge.sol
@@ -3,6 +3,8 @@
 
 pragma solidity 0.8.10;
 
+import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+
 import {IL1ERC20Bridge} from "./interfaces/IL1ERC20Bridge.sol";
 import {IL2ERC20Bridge} from "./interfaces/IL2ERC20Bridge.sol";
 import {IERC20Bridged} from "../token/interfaces/IERC20Bridged.sol";
@@ -46,6 +48,10 @@ contract L2ERC20TokenBridge is
         uint32 l1Gas_,
         bytes calldata data_
     ) external whenWithdrawalsEnabled onlySupportedL2Token(l2Token_) {
+        if (Address.isContract(msg.sender)) {
+            revert ErrorSenderNotEOA();
+        }
+
         _initiateWithdrawal(msg.sender, msg.sender, amount_, l1Gas_, data_);
     }
 
@@ -111,4 +117,7 @@ contract L2ERC20TokenBridge is
 
         emit WithdrawalInitiated(l1Token, l2Token, from_, to_, amount_, data_);
     }
+
+    error ErrorSenderNotEOA();
 }
+

--- a/test/mantle/L2ERC20TokenBridge.unit.test.ts
+++ b/test/mantle/L2ERC20TokenBridge.unit.test.ts
@@ -11,6 +11,7 @@ import testing, { unit } from "../../utils/testing";
 import { wei } from "../../utils/wei";
 import { assert } from "chai";
 
+
 unit("Mantle:: L2ERC20TokenBridge", ctxFactory)
   .test("l1TokenBridge()", async (ctx) => {
     assert.equal(
@@ -48,6 +49,20 @@ unit("Mantle:: L2ERC20TokenBridge", ctxFactory)
     await assert.revertsWith(
       l2TokenBridge.withdraw(stranger.address, wei`1 ether`, wei`1 gwei`, "0x"),
       "ErrorUnsupportedL2Token()"
+    );
+  })
+
+  .test("withdraw() :: not from EOA", async (ctx) => {
+    await assert.revertsWith(
+      ctx.l2TokenBridge
+        .connect(ctx.accounts.emptyContractEOA)
+        .withdraw(
+          ctx.stubs.l2Token.address,
+          wei`1 ether`,
+          wei`1 gwei`,
+          "0x"
+        ),
+      "ErrorSenderNotEOA()"
     );
   })
 


### PR DESCRIPTION
Fix for https://github.com/Verilog-Solutions/report-mantle-20230911/issues/4